### PR TITLE
fix: URLのカラムを2重に登録していたのを修正

### DIFF
--- a/db/migrate/20250826044444_add_url_to_onsens.rb
+++ b/db/migrate/20250826044444_add_url_to_onsens.rb
@@ -1,5 +1,0 @@
-class AddUrlToOnsens < ActiveRecord::Migration[8.0]
-  def change
-    add_column :onsens, :url, :string
-  end
-end


### PR DESCRIPTION
URLのカラムを2重に追加してエラーが出ていたため2つあるmigrationファイルのうち古い方を削除しました
deleted: \workspaces\rc2025_team4\db\migrate\20250826044444_add_url_to_onsens.rb