### PR TITLE
fix: 場所の情報の詳細表示の変更

### DIFF
--- a/app/views/admin/onsens/_onsen.html.erb
+++ b/app/views/admin/onsens/_onsen.html.erb
@@ -1,14 +1,12 @@
 <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2 text-sm text-gray-700 break-words">
   <dt class="font-semibold">名称</dt>
   <dd><%= onsen.name %></dd>
-  <dt class="font-semibold">緯度</dt>
-  <dd><%= onsen.geo_lat %></dd>
-  <dt class="font-semibold">経度</dt>
-  <dd><%= onsen.geo_lng %></dd>
+  <dt class="font-semibold">住所</dt>
+  <dd><%= onsen.address %></dd>
+  <dt class="font-semibold">URL</dt>
+  <dd><%= onsen.url %></dd>
   <dt class="font-semibold">説明</dt>
   <dd><%= onsen.description %></dd>
-  <dt class="font-semibold">タグ</dt>
-  <dd><%= onsen.tags %></dd>
   <dt class="font-semibold">タグ</dt>
   <dd><%= onsen.tags %></dd>
 </dl>


### PR DESCRIPTION
名称・緯度・経度・説明・タグ・タグ
の順番だったのを、

名称・住所・URL・説明・タグ
の表示に変更しました。

<img width="685" height="465" alt="image" src="https://github.com/user-attachments/assets/4db2046a-e893-46f2-9b8c-5489856e620d" />