### PR TITLE
feat: 詳細な開店・閉店時間を追加

### DIFF
--- a/app/models/onsen.rb
+++ b/app/models/onsen.rb
@@ -141,6 +141,24 @@ class Onsen < ApplicationRecord
       close_sec += 24 * 3600
     end
 
-    (open_sec <= now_sec && now_sec <= close_sec) ? "営業中" : "営業時間外"
+    if open_sec <= now_sec && now_sec <= close_sec
+      "営業中"
+
+    elsif now_sec < open_sec && open_sec - now_sec <= 30.minutes
+      "まもなく開店 (開店まであと#{(open_sec - now_sec) / 60}分)"
+
+    elsif close_sec - now_sec <= 30.minutes && now_sec < close_sec
+      "まもなく閉店 (閉店まであと#{(close_sec - now_sec) / 60}分)"
+
+    else
+      if now_sec < open_sec
+        # 今日の開店前
+        "営業時間外 (開店まであと#{(open_sec - now_sec) / 60}分)"
+      else
+        # 今日の営業は終了 → 翌日の開店まで待つ
+        minutes_until_tomorrow_open = (24 * 3600 - now_sec) + open_sec
+        "営業時間外 (明日の開店まであと#{minutes_until_tomorrow_open / 3600}時間)"
+      end
+    end
   end
 end


### PR DESCRIPTION
お店の開店/閉店時間に合わせてあとまもなく開店 (あとn分)など、営業時間外(明日の開店まであとn時間)などを表示出来るように変更しました

<img width="783" height="196" alt="image" src="https://github.com/user-attachments/assets/ca36f942-e981-41ca-ab50-c045bf92664a" />