### PR TITLE
fix: グルメ管理から管理画面に変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,7 +20,7 @@ module ApplicationHelper
   # @return [Array<Hash>] 管理サイト用ナビゲーションリンク
   def admin_navigation_links(current_path)
     create_navigation_link_set([
-      { path: "/admin/onsens", label: t("views.navigation.onsen_management"), aria_label: "グルメ管理", current_check: -> { current_path.start_with?("/admin/onsens") } },
+      { path: "/admin/onsens", label: t("views.navigation.onsen_management"), aria_label: "管理画面", current_check: -> { current_path.start_with?("/admin/onsens") } },
       { path: "/", label: t("views.navigation.public_site"), aria_label: "公開サイト", current_check: -> { false } }
     ])
   end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -79,7 +79,7 @@ ja:
       site_title: 松江グルメマップ
       search: 検索
       admin: 管理画面
-      onsen_management: グルメ管理
+      onsen_management: 管理画面
       public_site: 公開サイト
     onsens:
     onsens:


### PR DESCRIPTION
グルメ管理から管理画面に名前を変更

<img width="385" height="338" alt="image" src="https://github.com/user-attachments/assets/0d17ef59-1f55-48ec-afc6-bdff41fccd54" />
