### PR TITLE
feat: 詳細情報画面の改善

### DIFF
--- a/app/views/admin/onsens/_onsen.html.erb
+++ b/app/views/admin/onsens/_onsen.html.erb
@@ -2,9 +2,14 @@
   <dt class="font-semibold">名称</dt>
   <dd><%= onsen.name %></dd>
 
-  <dt class="font-semibold">住所</dt>
-  <dd><%= onsen.address %></dd>           
-             
+  <dt class="font-semibold">住所(クリックしてGoogleマップで表示)</dt>
+  <dd>
+    <%= link_to onsen.address,
+      "https://www.google.com/maps/search/?api=1&query=#{ERB::Util.url_encode(onsen.address)}",
+      target: "_blank",
+      rel: "noopener noreferrer" %>
+  </dd>
+
   <dt class="font-semibold">緯度</dt>
   <dd><%= onsen.geo_lat %></dd>
   
@@ -12,7 +17,7 @@
   <dd><%= onsen.geo_lng %></dd>
 
   <dt class="font-semibold">URL</dt>
-  <dd><%= onsen.url %></dd>
+  <dd><%= link_to onsen.url, onsen.url, target: "_blank" %></dd>
   
   <dt class="font-semibold">始業時間</dt>
   <dd><%= onsen.sales_s %></dd>


### PR DESCRIPTION
建物の詳細表示の画面で、住所をクリックするとGoogleマップのページにジャンプする様になりました
URLの項目がクリック可能になりました
<img width="941" height="344" alt="image" src="https://github.com/user-attachments/assets/62775334-78e7-47ee-b194-5479d9386040" />
